### PR TITLE
Add Bay Area 511 transit arrival tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,14 @@ TODOIST_SHOPPING_PROJECT_ID=
 TODOIST_TODO_DUE_DETAILS=Today
 TODOIST_SHOPPING_DUE_DETAILS=Saturday
 
+# Bay Area 511 next transit tool
+# Set these to enable predicted arrival times for a public transit route.
+# FRIENDLY_NAME should include the line as the first word, e.g. "L train" or "38 bus".
+BAY_AREA_511_API_KEY=
+BAY_AREA_511_AGENCY=
+BAY_AREA_511_STOP_CODE=
+BAY_AREA_511_FRIENDLY_NAME=
+
 ###
 # LOGGING (OPTIONAL)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Aurora supports a plugin system for tools. The follwing are included:
 1. Timers - set, list and delete timers by name. 
 2. Todoist - add shopping and to do list items. 
 3. Perplexity Sonar - look up information using the Sonar API.
-4. Cheese Night - a simple tool to decide which kid gets the first pick of chores. 
+4. Cheese Night - a simple tool to decide which kid gets the first pick of chores.
+5. Next Transit - get predicted arrival times for a configured Bay Area public transit route.
 
 Tools are only included in realtime calls if configured (see .env.example), and it's easy to add a new tool by following the examples. If you make something useful please send a pull request. I'll add more tools over time and plan to look at MCP support too as this was recently added to the realtime API.  
 

--- a/settings.py
+++ b/settings.py
@@ -152,6 +152,28 @@ class Settings(BaseSettings):
         validation_alias="TODOIST_SHOPPING_DUE_DETAILS",
     )
 
+    # Bay Area 511 transit tool (optional)
+    bay_area_511_api_key: str = Field(
+        default="",
+        description="Bay Area 511 API key",
+        validation_alias="BAY_AREA_511_API_KEY",
+    )
+    bay_area_511_agency: str | None = Field(
+        default=None,
+        description="Transit agency code for Bay Area 511",
+        validation_alias="BAY_AREA_511_AGENCY",
+    )
+    bay_area_511_stop_code: str | None = Field(
+        default=None,
+        description="Stop code for Bay Area 511",
+        validation_alias="BAY_AREA_511_STOP_CODE",
+    )
+    bay_area_511_friendly_name: str | None = Field(
+        default=None,
+        description="Friendly name for the transit line (e.g., 'L train' or '38 bus')",
+        validation_alias="BAY_AREA_511_FRIENDLY_NAME",
+    )
+
 
 # A singleton-style instance for convenient imports
 settings = Settings()

--- a/tools/next_transit.py
+++ b/tools/next_transit.py
@@ -1,0 +1,101 @@
+import json
+import logging
+from datetime import datetime
+from zoneinfo import ZoneInfo
+from typing import Optional, Any
+
+import requests
+
+from settings import settings
+from .base import Tool
+
+
+class NextTransitTool(Tool):
+    """Tool to fetch predicted arrival times for a configured public transit route using the Bay Area 511 API."""
+
+    def __init__(self, log: Optional[logging.Logger] = None, audio_manager: Any | None = None):
+        super().__init__(log=log, audio_manager=audio_manager)
+        friendly = (settings.bay_area_511_friendly_name or "transit").strip()
+        # sanitize for tool name
+        sanitized = "".join(c.lower() if c.isalnum() else "_" for c in friendly).strip("_")
+        self.friendly_name = friendly
+        self.name = f"next_{sanitized}"
+
+    def is_configured(self) -> bool:
+        try:
+            return all(
+                [
+                    (settings.bay_area_511_api_key or "").strip(),
+                    (settings.bay_area_511_agency or "").strip(),
+                    (settings.bay_area_511_stop_code or "").strip(),
+                    (settings.bay_area_511_friendly_name or "").strip(),
+                ]
+            )
+        except Exception:
+            self.log.exception("Error checking NextTransitTool configuration")
+            return False
+
+    def manifest(self) -> dict:
+        return {
+            "name": self.name,
+            "type": "function",
+            "description": f"Get the predicted arrival time for the next {self.friendly_name}.",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        }
+
+    def handle(self, tool_name: str, arguments: Any) -> Optional[str]:
+        if tool_name != self.name:
+            return None
+
+        api_key = settings.bay_area_511_api_key
+        agency = settings.bay_area_511_agency
+        stop_code = settings.bay_area_511_stop_code
+        line_ref = (settings.bay_area_511_friendly_name or "").split()[0]
+
+        url = (
+            "https://api.511.org/transit/StopMonitoring?"
+            f"api_key={api_key}&agency={agency}&stopCode={stop_code}&Format=json"
+        )
+        response = None
+        try:
+            response = requests.get(url)
+            response.raise_for_status()
+            raw = response.content.decode("utf-8-sig")
+            data = json.loads(raw)
+
+            predicted_arrival_times = []
+            visits = (
+                data.get("ServiceDelivery", {})
+                .get("StopMonitoringDelivery", {})
+                .get("MonitoredStopVisit", [])
+            )
+            for visit in visits:
+                journey = visit.get("MonitoredVehicleJourney", {})
+                if journey.get("LineRef") != line_ref:
+                    continue
+                expected_arrival_time = journey.get("MonitoredCall", {}).get(
+                    "ExpectedArrivalTime"
+                )
+                if not expected_arrival_time:
+                    continue
+                eta = datetime.fromisoformat(expected_arrival_time.replace("Z", "+00:00"))
+                eta = eta.astimezone(ZoneInfo("America/Los_Angeles"))
+                now = datetime.now(ZoneInfo("America/Los_Angeles"))
+                minutes = (eta - now).total_seconds() / 60
+                predicted_arrival_times.append(minutes)
+
+            if not predicted_arrival_times:
+                return f"No upcoming {self.friendly_name} arrivals found."
+
+            rounded_times = [f"{round(m)}mins" for m in predicted_arrival_times]
+            return ", ".join(rounded_times)
+        except Exception as err:
+            self.log.exception("Failed to get transit prediction")
+            return f"Failed to get {self.friendly_name} prediction: {err}"
+        finally:
+            if response is not None:
+                response.close()
+
+
+def create_tool(log: Optional[logging.Logger] = None, audio_manager: Any | None = None) -> Tool:
+    return NextTransitTool(log=log, audio_manager=audio_manager)


### PR DESCRIPTION
## Summary
- add configurable tool to fetch next public transit arrival times via Bay Area 511 API
- expose 511 API key, agency, stop code and friendly route name in settings and `.env.example`
- document new tool in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5b4ab0324832aa981e55fb69bae73